### PR TITLE
fix: adding main-two-way-binding.ts to tsconfig.app.json

### DIFF
--- a/code-samples/Angular9/chapter2/bindings/src/tsconfig.app.json
+++ b/code-samples/Angular9/chapter2/bindings/src/tsconfig.app.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "main-one-way-binding.ts",
+    "main-two-way-binding.ts",
     "polyfills.ts"
   ],
   "include": [


### PR DESCRIPTION
I had to make this change in order to run the "twoway" project with Angular9. This is part of the chapter 2